### PR TITLE
fix: limit number length

### DIFF
--- a/src/components/UnixSection.tsx
+++ b/src/components/UnixSection.tsx
@@ -22,7 +22,7 @@ export default function UnixSection({
 
   function onUnixTimeChange(event: React.ChangeEvent<HTMLInputElement>) {
     const value = event.target.value;
-    const unixTime = parseInt(value);
+    const unixTime = parseInt(value.slice(0, 10));
     if (isNaN(unixTime)) {
       return;
     }


### PR DESCRIPTION
Closes keenanlk/epocher-v2/issues/43

## Description
Limits the length of unix input

## Changes
only sets the first 10 digits

## Screenshots (if applicable)